### PR TITLE
Fix TOTP Key / QR code

### DIFF
--- a/models/totp.js
+++ b/models/totp.js
@@ -77,6 +77,7 @@ module.exports.create = (apiKeyValue, apiSecret, {issuer, label = 'SecretKey'} =
         const apiResponse = {
           'uuid': totpUuid,
           'totpKey': totpKey,
+          'otpAuthUrl': otpAuthUrl,
           'imageUrl': dataUrl
         };
         response.returnSuccess(apiResponse, callback);

--- a/models/totp.js
+++ b/models/totp.js
@@ -42,7 +42,8 @@ module.exports.create = (apiKeyValue, apiSecret, {issuer, label = 'SecretKey'} =
     const otpSecrets = speakeasy.generateSecret();
     let otpAuthUrlOptions = {
       'label': label,
-      'secret': otpSecrets.base32
+      'secret': otpSecrets.base32,
+      'encoding': 'base32'
     };
     if (issuer) {
       otpAuthUrlOptions.issuer = issuer;


### PR DESCRIPTION
It turned out that the method for generating a more customized otpAuthUrl (used primarily for generating a QR code) expected the secret to be ascii encoded if no encoding was specified, so the secret included in the QR code no longer matched the TOTP Key we were encrypting and saving in the database. This fixes that.