### PR TITLE
Control access to /api-key endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Simple standalone API for creating and validating TOTP codes
 
 - A consumer of this API does a `POST` to `/api-key`, providing an email
   address.
+  * NOTE: To keep this API from being wide open to anyone, we protect our
+    endpoints at/under `/api-key` with API Gateway's built-in api keys, which
+    must be provided as an `x-api-key` header in the HTTP request.
 - We create a new API Key and email it to that email address.
 - The consumer does a `POST` to `/api-key/activate`, providing the email address
   and the API Key.

--- a/api.raml
+++ b/api.raml
@@ -10,6 +10,10 @@ protocols: [HTTPS]
     new, unique API Key. You must then make a separate call to activate that API
     Key. Protect your API Key as a secret.
   post:
+    headers:
+      x-api-key:
+        description: The AWS API Gateway api key's value (obtained from AWS).
+        required: true
     body:
       application/json:
         properties:
@@ -29,6 +33,10 @@ protocols: [HTTPS]
         description: |
           The request was unacceptable for some reason. See the error message.
       401:
+      403:
+        description: |
+          No valid API Gateway api key was provided (not to be confused with
+          our internal API Keys).
 
 /api-key/activate:
   description: |
@@ -36,6 +44,10 @@ protocols: [HTTPS]
     further calls. This call can only be made once per API Key, so make sure you
     save the API Secret somewhere safe.
   post:
+    headers:
+      x-api-key:
+        description: The AWS API Gateway api key's value (obtained from AWS).
+        required: true
     body:
       application/json:
         properties:
@@ -62,6 +74,10 @@ protocols: [HTTPS]
                 "apiSecret": "ABCDEFGHIJKLMNOPQRSTUVWXYZ+abcdefgh/ijklmno="
               }
       401:
+      403:
+        description: |
+          No valid API Gateway api key was provided (not to be confused with
+          our internal API Keys).
       404:
         description: |
           No such API key was found with that email address.

--- a/helpers/request-helper.js
+++ b/helpers/request-helper.js
@@ -10,9 +10,6 @@ module.exports.getTotpHeaders = (headers = {}) => {
 };
 
 module.exports.getJsonData = (jsonString) => {
-  var isOnlyWhitespace = /^\s+$/.test(jsonString);
-  if (isOnlyWhitespace) {
-    return {};
-  }
-  return JSON.parse(jsonString || '{}');
+  jsonString = jsonString || '{}';
+  return JSON.parse(jsonString.trim() || '{}');
 };

--- a/helpers/request-helper.js
+++ b/helpers/request-helper.js
@@ -10,5 +10,9 @@ module.exports.getTotpHeaders = (headers = {}) => {
 };
 
 module.exports.getJsonData = (jsonString) => {
+  var isOnlyWhitespace = /^\s+$/.test(jsonString);
+  if (isOnlyWhitespace) {
+    return {};
+  }
   return JSON.parse(jsonString || '{}');
 };

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,8 @@ provider:
   #   256 MB = 71 ms
   #   128 MB = 159 ms
   memorySize: 512
+  apiKeys:
+    - ${self:custom.namespace}_global
   iamRoleStatements:
     - Effect: "Allow"
       Action:
@@ -39,6 +41,7 @@ functions:
       - http:
           path: api-key/activate
           method: post
+          private: true
   apiKeyCreate:
     handler: handlers/api-key.create
     name: ${self:custom.namespace}_apiKeyCreate
@@ -48,6 +51,7 @@ functions:
       - http:
           path: api-key
           method: post
+          private: true
   totpCreate:
     handler: handlers/totp.create
     name: ${self:custom.namespace}_totpCreate


### PR DESCRIPTION
Closes #22 

This also protects against the JSON-parsing blowing up (instead returning a useful error message) if a JSON string of "\r\n" is provided (which I apparently accidentally did at one point).