### PR TITLE
Exclude aws-sdk npm package from our zip file.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -29,6 +29,10 @@ custom:
   namespace: ${self:service}_${self:custom.stage}
   apiKeyTable: ${self:custom.namespace}_api-key
 
+package:
+  exclude:
+    - node_modules/aws-sdk/**
+
 functions:
   apiKeyActivate:
     handler: handlers/api-key.activate


### PR DESCRIPTION
It is already globally installed and available to NodeJS code running in AWS Lambda.

Closes #13 